### PR TITLE
Add ubuntu-24.04-x64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13, macos-14, macos-arm-oss, windows-2019, windows-2022 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-11, macos-12, macos-13, macos-14, macos-arm-oss, windows-2019, windows-2022 ]
         ruby: [
           '1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', ruby-head,
           jruby, jruby-head,

--- a/common.js
+++ b/common.js
@@ -165,6 +165,7 @@ export async function hashFile(file) {
 const GitHubHostedPlatforms = [
   'ubuntu-20.04-x64',
   'ubuntu-22.04-x64',
+  'ubuntu-24.04-x64',
   'macos-11-x64',
   'macos-12-x64',
   'macos-13-x64',


### PR DESCRIPTION
See https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/